### PR TITLE
CSS 에서 드롭다운 시 생기는 택스트 창 클릭 불가능 만듦

### DIFF
--- a/style.css
+++ b/style.css
@@ -265,3 +265,8 @@ section[data-testid="stSidebar"] div[role="radiogroup"] label:has(input:checked)
     border-color: #1d4ed8;
     font-weight: 600;
 }
+
+/* Streamlit Selectbox 내부의 검색 입력창을 숨김 */
+div[data-baseweb="select"] input {
+    caret-color: transparent !important; /* 커서(깜박이) 숨김 */
+}


### PR DESCRIPTION
드롭다운시 생기는 택스트창 입력불가하게 만들기